### PR TITLE
fix: link mark no longer building with misnamed getCustomAttrs (#2729)

### DIFF
--- a/apps/editor/src/wysiwyg/marks/link.ts
+++ b/apps/editor/src/wysiwyg/marks/link.ts
@@ -53,8 +53,7 @@ export class Link extends Mark {
         attrs.rawHTML || 'a',
         {
           href: escapeXml(attrs.linkUrl),
-          // @ts-ignore
-          ...(this.linkAttributes as DOMOutputSpec),
+          ...this.linkAttributes,
           ...getCustomAttrs(attrs),
         },
       ],


### PR DESCRIPTION
Co-authored-by: Jethro Larson <jethro.larson@tableau.com>

<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [ ] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
